### PR TITLE
Add default value to Mongo databaseUrl

### DIFF
--- a/config.js
+++ b/config.js
@@ -57,7 +57,7 @@ if (process.env.ALIAS_SERVER_URI && process.env.ALIAS_SERVER_URI !== '') {
 
 module.exports = {
   mongo: {
-    databaseUrl: process.env.MONGODB_URI
+    databaseUrl: process.env.MONGODB_URI || 'mongodb://localhost:27017/knot_cloud'
   },
   port: parseInt(process.env.PORT) || 3000,
   tls: {


### PR DESCRIPTION
In order to avoid steps in the quick starter guide, having a default value to databaseUrl param, when a process.env is not set, would make things easier to new users, and stills compatible with users that has environment variables.

It will help knot to having a quick start and making it even a "easy way" to develop in IoT.