### PR TITLE
fix(database): update MongoDB connection settings

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -6,7 +6,15 @@ var deviceIDName = 'deviceID';
 if (config.mongo && config.mongo.databaseUrl) {
 
   var mongojs = require('mongojs');
-  var db = mongojs(config.mongo.databaseUrl);
+  var db = mongojs(
+    config.mongo.databaseUrl,
+    null,
+    {
+      socketTimeoutMS: 30000,
+      connectTimeoutMS: 60000,
+      reconnectTries: Number.MAX_VALUE
+    }
+  );
   module.exports = {
     deviceIDName: deviceIDName,
     devices: db.collection('devices'),


### PR DESCRIPTION
This patch increase the socketTimeout and connectTimeout to support
scenarios in which is slow to establish the connection. Besides,
reconnectTries was updated to Number.MAX_VALUE in order to client
always try to reconnect when the server is down.